### PR TITLE
Added parameter for message priority

### DIFF
--- a/Project/Send-MailKitMessage.csproj
+++ b/Project/Send-MailKitMessage.csproj
@@ -4,9 +4,9 @@
     <AssemblyName>Send_MailKitMessage</AssemblyName>
     <Authors>Eric Austin</Authors>
     <PackageId>Send-MailKitMessage</PackageId>
-    <Version>3.2.0-preview2</Version>
+    <Version>3.2.0-preview1</Version>
     <AssemblyVersion>3.0.0</AssemblyVersion>
-    <FileVersion>3.2.0.12</FileVersion>
+    <FileVersion>3.2.0.11</FileVersion>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <!-- this causes the build to include all assemblies in bin/Debug, which is necessary for testing -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/Project/Send-MailKitMessage.csproj
+++ b/Project/Send-MailKitMessage.csproj
@@ -4,9 +4,9 @@
     <AssemblyName>Send_MailKitMessage</AssemblyName>
     <Authors>Eric Austin</Authors>
     <PackageId>Send-MailKitMessage</PackageId>
-    <Version>3.2.0-preview1</Version>
+    <Version>3.2.0-preview2</Version>
     <AssemblyVersion>3.0.0</AssemblyVersion>
-    <FileVersion>3.2.0.11</FileVersion>
+    <FileVersion>3.2.0.12</FileVersion>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <!-- this causes the build to include all assemblies in bin/Debug, which is necessary for testing -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/Project/Send_MailKitMessage.cs
+++ b/Project/Send_MailKitMessage.cs
@@ -37,6 +37,26 @@ namespace Send_MailKitMessage
         }
     }
 
+    internal static class EmailPriority
+    {
+        public static MessagePriority GetPriority(string priority)
+        {
+            switch (priority)
+            {
+                case "0": return MessagePriority.NonUrgent;
+                case "1": return MessagePriority.Normal;
+                case "2": return MessagePriority.Urgent;
+                case "NonUrgent": return MessagePriority.NonUrgent;
+                case "Normal": return MessagePriority.Normal;
+                case "Urgent": return MessagePriority.Urgent;
+                //Low and High used by Send-MailMessage Cmdlet; including as aliases
+                case "Low": return MessagePriority.NonUrgent;
+                case "High": return MessagePriority.Urgent;
+                default: throw new Exception($"Priority '{priority}' not found. Valid priorities include: NonUrgent, Normal, Urgent.");
+            }
+        }
+    }
+
     [Cmdlet(VerbsCommunications.Send, "MailKitMessage")]    //I think the [CmdletBinding] piece is applicable to true PowerShell functions, not compiled cmdlets https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_functions_cmdletbindingattribute?view=powershell-7.1#long-description
     [OutputType(typeof(void))]
     public class Send_MailKitMessage : PSCmdlet
@@ -56,6 +76,10 @@ namespace Send_MailKitMessage
         [Parameter(
             Mandatory = true)]
         public int Port { get; set; }
+
+        [Parameter(
+            Mandatory = false)]
+        public string Priority { get; set; }
 
         [Parameter(
             Mandatory = true)]
@@ -105,6 +129,11 @@ namespace Send_MailKitMessage
 
             try
             {
+                //priority
+                if (!string.IsNullOrWhiteSpace(Priority))
+                {
+                    Message.Priority = EmailPriority.GetPriority(Priority);
+                }
 
                 //from
                 Message.From.Add(From);

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ $SMTPServer = "SMTPServer"
 #port ([int], required)
 $Port = PortNumber
 
+#priority ([string], optional)
+$Priority = [string]"Priority"
+
 #sender ([MimeKit.MailboxAddress] http://www.mimekit.net/docs/html/T_MimeKit_MailboxAddress.htm, required)
 $From = [MimeKit.MailboxAddress]"SenderEmailAddress"
 
@@ -59,6 +62,7 @@ $Parameters = @{
     "Credential" = $Credential
     "SMTPServer" = $SMTPServer
     "Port" = $Port
+    "Priority" = $Priority
     "From" = $From
     "RecipientList" = $RecipientList
     "CCList" = $CCList
@@ -74,6 +78,9 @@ Send-MailKitMessage @Parameters
 ```
 
 # Releases
+### 3.2.0-preview2
+* Added parameter for message priority
+
 ### 3.2.0-preview1
 * Add support for Windows PowerShell
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,6 @@ $Parameters = @{
 Send-MailKitMessage @Parameters
 ```
 
-# Releases
-### 3.2.0-preview2
-* Added parameter for message priority
-
 ### 3.2.0-preview1
 * Add support for Windows PowerShell
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $Parameters = @{
 Send-MailKitMessage @Parameters
 ```
 
+# Releases
 ### 3.2.0-preview1
 * Add support for Windows PowerShell
 

--- a/Utilities/Use module.ps1
+++ b/Utilities/Use module.ps1
@@ -31,6 +31,7 @@ if (-not (Test-Path -Path $ParametersFileLocation))
         Password = [string]::Empty
         SMTPServer = [string]::Empty
         Port = [string]::Empty
+        Priority = [string]::Empty
         From = [string]::Empty
         To = [string]::Empty
         CC = [string]::Empty
@@ -61,6 +62,9 @@ $Parameters = @{
 
     #Port (required)
     "Port" = $ParametersFile."Port"
+
+    #Priority (optional)
+    "Priority" = if ([string]::IsNullOrWhiteSpace($ParametersFile."Priority")) { $null } else { [string]$ParametersFile."Priority" }
 
     #Sender (required) (http://www.mimekit.net/docs/html/T_MimeKit_MailboxAddress.htm)
     "From" = [MimeKit.MailboxAddress]$ParametersFile."From"


### PR DESCRIPTION
Added new optional parameter `-Priority` for setting the message priority as `NonUrgent` (0), `Normal` (1), or `Urgent` (2).

Included `Low` and `High` as aliases for `NonUrgent` and `Urgent` respectively, as the now deprecated `Send-MailMessage` Cmdlet uses `Low`, `Normal`, and `High` for message priority.