### PR TITLE
3.2.0 preview2

### DIFF
--- a/Project/Send_MailKitMessage.cs
+++ b/Project/Send_MailKitMessage.cs
@@ -85,18 +85,22 @@ namespace Send_MailKitMessage
             Mandatory = true)]
         public MailboxAddress From { get; set; }
 
+        [Alias("ReplyTo")]
         [Parameter(
             Mandatory = false)]
         public InternetAddressList ReplyToList { get; set; }
 
+        [Alias("To")]
         [Parameter(
             Mandatory = true)]
         public InternetAddressList RecipientList { get; set; }
 
+        [Alias("CC")]
         [Parameter(
             Mandatory = false)]
         public InternetAddressList CCList { get; set; }
 
+        [Alias("BCC")]
         [Parameter(
             Mandatory = false)]
         public InternetAddressList BCCList { get; set; }
@@ -113,6 +117,7 @@ namespace Send_MailKitMessage
             Mandatory = false)]
         public string HTMLBody { get; set; }
 
+        [Alias("Attachments")]
         [Parameter(
             Mandatory = false)]
         public string[] AttachmentList { get; set; }

--- a/Project/Send_MailKitMessage.cs
+++ b/Project/Send_MailKitMessage.cs
@@ -74,8 +74,8 @@ namespace Send_MailKitMessage
         public string SMTPServer { get; set; }
 
         [Parameter(
-            Mandatory = true)]
-        public int Port { get; set; }
+            Mandatory = false)]
+        public int Port { get; set; } = 25; //default to port 25 if no value is passed
 
         [Parameter(
             Mandatory = false)]

--- a/Project/Send_MailKitMessage.cs
+++ b/Project/Send_MailKitMessage.cs
@@ -86,6 +86,10 @@ namespace Send_MailKitMessage
         public MailboxAddress From { get; set; }
 
         [Parameter(
+            Mandatory = false)]
+        public InternetAddressList ReplyToList { get; set; }
+
+        [Parameter(
             Mandatory = true)]
         public InternetAddressList RecipientList { get; set; }
 
@@ -137,6 +141,12 @@ namespace Send_MailKitMessage
 
                 //from
                 Message.From.Add(From);
+
+                //replyto
+                if (ReplyToList?.Count > 0)
+                {
+                    Message.ReplyTo.AddRange(ReplyToList);
+                }
 
                 //to
                 Message.To.AddRange(RecipientList);

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ $Priority = [string]"Priority"
 #sender ([MimeKit.MailboxAddress] http://www.mimekit.net/docs/html/T_MimeKit_MailboxAddress.htm, required)
 $From = [MimeKit.MailboxAddress]"SenderEmailAddress"
 
+#replyto list ([MimeKit.InternetAddressList] http://www.mimekit.net/docs/html/T_MimeKit_InternetAddressList.htm, optional)
+$ReplyToList = [MimeKit.InternetAddressList]::new()
+$ReplyToList.Add([MimeKit.InternetAddress]"ReplyTo1EmailAddress")
+
 #recipient list ([MimeKit.InternetAddressList] http://www.mimekit.net/docs/html/T_MimeKit_InternetAddressList.htm, required)
 $RecipientList = [MimeKit.InternetAddressList]::new()
 $RecipientList.Add([MimeKit.InternetAddress]"Recipient1EmailAddress")
@@ -64,6 +68,7 @@ $Parameters = @{
     "Port" = $Port
     "Priority" = $Priority
     "From" = $From
+    "ReplyToList" = $ReplyToList
     "RecipientList" = $RecipientList
     "CCList" = $CCList
     "BCCList" = $BCCList

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $Credential = [System.Management.Automation.PSCredential]::new("Username", (Conv
 #SMTP server ([string], required)
 $SMTPServer = "SMTPServer"
 
-#port ([int], required)
+#port ([int], optional)
 $Port = PortNumber
 
 #priority ([string], optional)

--- a/Utilities/Use module.ps1
+++ b/Utilities/Use module.ps1
@@ -33,6 +33,7 @@ if (-not (Test-Path -Path $ParametersFileLocation))
         Port = [string]::Empty
         Priority = [string]::Empty
         From = [string]::Empty
+        ReplyTo = [string]::Empty
         To = [string]::Empty
         CC = [string]::Empty
         BCC = [string]::Empty
@@ -68,6 +69,9 @@ $Parameters = @{
 
     #Sender (required) (http://www.mimekit.net/docs/html/T_MimeKit_MailboxAddress.htm)
     "From" = [MimeKit.MailboxAddress]$ParametersFile."From"
+
+    #ReplyTo list (optional) (http://www.mimekit.net/docs/html/T_MimeKit_InternetAddressList.htm)
+    "ReplyToList" = if ([string]::IsNullOrWhiteSpace($ParametersFile."ReplyTo")) { $null } else { [MimeKit.InternetAddressList]$ParametersFile."ReplyTo" }
 
     #Recipient list (at least one recipient required) (http://www.mimekit.net/docs/html/T_MimeKit_InternetAddressList.htm)
     "RecipientList" = [MimeKit.InternetAddressList]$ParametersFile."To"

--- a/Utilities/Use module.ps1
+++ b/Utilities/Use module.ps1
@@ -61,8 +61,8 @@ $Parameters = @{
     #SMTP server (required)
     "SMTPServer" = $ParametersFile."SMTPServer"
 
-    #Port (required)
-    "Port" = $ParametersFile."Port"
+    #Port (optional)
+    "Port" = if ([string]::IsNullOrWhiteSpace($ParametersFile."Port")) { 25 } else { $ParametersFile."Port" }
 
     #Priority (optional)
     "Priority" = if ([string]::IsNullOrWhiteSpace($ParametersFile."Priority")) { $null } else { [string]$ParametersFile."Priority" }


### PR DESCRIPTION
Added optional parameter `-ReplyToList` for setting the `MimeMessage.ReplyTo` property

Added default value of `25` for `-Port` parameter, as this is the default SMTP port

Added parameter aliases for increased backwards compatibility with deprecated Send-MailMessage Cmdlet:
`To` : alias for `RecipientList`
`CC` : alias for `CCList`
`BCC` : alias for `BCCList`
`Attachments` : alias for `AttachmentList`
`ReplyTo` : alias for `ReplyToList`